### PR TITLE
export libxml2/2.12.6

### DIFF
--- a/.github/workflows/ni_upload_to_jfrog.yml
+++ b/.github/workflows/ni_upload_to_jfrog.yml
@@ -38,6 +38,7 @@ jobs:
       - run: conan export recipes/nlohmann_json/all --version 3.11.3
       - run: conan export recipes/spdlog/all --version 1.14.1
       - run: conan export recipes/dbus-cxx/2.x.x --version 2.4.0
+      - run: conan export recipes/libxml2/all --version 2.12.6
         # upload everthing
       - run: conan upload -r rnd-conan-ci -c "*"
 


### PR DESCRIPTION
Team is exploring using conanhelper to pull in libxml2 to replace tinyxml due to security vulnerabilities.
Instead of creating a new thirdpartyexport, we are recommending the team to use conanhelper to get the necessary libraries.

Specify library name and version: libxml2/2.12.6

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
