### PR TITLE
export gtest/1.10.0

### DIFF
--- a/.github/workflows/ni_upload_to_jfrog.yml
+++ b/.github/workflows/ni_upload_to_jfrog.yml
@@ -28,6 +28,7 @@ jobs:
         # export packages to local cache
       - run: conan export recipes/expat/all --version 2.6.2
       - run: conan export recipes/fmt/all --version 10.2.1
+      - run: conan export recipes/gtest/all --version 1.10.0
       - run: conan export recipes/gtest/all --version 1.12.1
       - run: conan export recipes/gtest/all --version 1.14.0
       - run: conan export recipes/gtest/all --version 1.15.0


### PR DESCRIPTION
Specify library name and version:  **gtest/1.10.0**

As part of C++ compiler upgrade efforts, we are looking into the see if we can utilize conanHelper for some of the third-party dependencies. We need older gtest 1.10.0 to support old GCC 4.9 open embedded compiler.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
