### PR TITLE
export tinyxml2/10.0.0

### DIFF
--- a/.github/workflows/ni_upload_to_jfrog.yml
+++ b/.github/workflows/ni_upload_to_jfrog.yml
@@ -41,6 +41,7 @@ jobs:
       - run: conan export recipes/spdlog/all --version 1.14.1
       - run: conan export recipes/dbus-cxx/2.x.x --version 2.4.0
       - run: conan export recipes/libxml2/all --version 2.12.6
+      - run: conan export recipes/tinyxml2/all --version 10.0.0
         # upload everthing
       - run: conan upload -r rnd-conan-ci -c "*"
 


### PR DESCRIPTION
Tinyxml2 to replace tinyxml dependency to address security vulnerabilities

Specify library name and version:  tinyxml2/10.0.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
